### PR TITLE
Music Player Auto Hide Functionality And Options #1 

### DIFF
--- a/music-player/contents/ui/config/ConfigAppearance.qml
+++ b/music-player/contents/ui/config/ConfigAppearance.qml
@@ -420,12 +420,12 @@ Item {
         font.pixelSize: 11
         text: configAppearance.cfg_preferredPlayer === ""
             ? i18n("Requires a locked (specific) player to work.")
-            : i18n("Disappears from panel when \"%1\" is not running.", configAppearance.cfg_preferredPlayer)
+            : i18n("Disappears when \"%1\" is not running.", configAppearance.cfg_preferredPlayer)
     }
 
     CheckBox {
         id: hideWhenNotPlayingCheckbox
-        text: i18n("Hide in panel when nothing is playing")
+        text: i18n("Hide when nothing is playing")
         checked: configAppearance.cfg_hideWhenNotPlaying
         onCheckedChanged: configAppearance.cfg_hideWhenNotPlaying = checked
     }
@@ -435,7 +435,7 @@ Item {
         wrapMode: Text.Wrap
         opacity: 0.6
         font.pixelSize: 11
-        text: i18n("Widget disappears from panel when paused or stopped.")
+        text: i18n("Widget disappears when paused or stopped.")
     }
 
     } // Kirigami.FormLayout

--- a/music-player/contents/ui/main.qml
+++ b/music-player/contents/ui/main.qml
@@ -189,21 +189,24 @@ PlasmoidItem {
     // Plasmoid Status (visibility) Logic
     // ---------------------------------------------------------
     function updateStatus() {
+        // Rule 2: Locked player is missing → hidden (autoHide option)
+        if (autoHideWhenInactive && preferredPlayer !== "" && !hasPlayer) {
+            Plasmoid.status = PlasmaCore.Types.HiddenStatus
+            return
+        }
+
+        // Rule 3: Nothing playing → hidden (hideWhenNotPlaying option)
+        if (hideWhenNotPlaying && !isPlaying) {
+            Plasmoid.status = PlasmaCore.Types.HiddenStatus
+            return
+        }
+        
         // Rule 1: Not in panel → always passive (desktop widget, no panel slot needed)
         if (!isInPanel) {
             Plasmoid.status = PlasmaCore.Types.PassiveStatus
             return
         }
-        // Rule 2: Locked player is missing → passive (autoHide option)
-        if (autoHideWhenInactive && preferredPlayer !== "" && !hasPlayer) {
-            Plasmoid.status = PlasmaCore.Types.PassiveStatus
-            return
-        }
-        // Rule 3: Nothing playing in panel → passive (hideWhenNotPlaying option)
-        if (hideWhenNotPlaying && !isPlaying) {
-            Plasmoid.status = PlasmaCore.Types.PassiveStatus
-            return
-        }
+
         // Otherwise: active
         Plasmoid.status = PlasmaCore.Types.ActiveStatus
     }
@@ -601,10 +604,13 @@ PlasmoidItem {
             return "compact"
         }
         
+        readonly property bool isEditMode: Plasmoid.userConfiguring || (Plasmoid.containment && Plasmoid.containment.corona && Plasmoid.containment.corona.editMode)
+        
         Rectangle {
             id: mainRect
             anchors.fill: parent
             anchors.margins: Plasmoid.configuration.edgeMargin !== undefined ? Plasmoid.configuration.edgeMargin : 10
+            visible: fullRep.isEditMode || (Plasmoid.status !== PlasmaCore.Types.HiddenStatus)
             color: root.isInPanel ? "transparent" : Kirigami.Theme.backgroundColor
             opacity: root.isInPanel ? 1 : root.cfg_backgroundOpacity
             radius: root.cfg_widgetRadius


### PR DESCRIPTION
As mentioned in #1, this PR adds the ability for the widget to properly hide itself when placed on the desktop (previously, this only worked well in the panel). I have also updated the visibility options in the Appearance settings so they apply universally.

The visibility logic now respects two options:

Hide when locked player is not active: The widget completely hides if a preferred player is set but is not currently running.
Hide when nothing is playing: The widget disappears if playback stops or pauses.
Note on testing: I have tested this extensively using the Spotify Web App and verified that the desktop widget successfully hides and reappears (including in Edit Mode). It would be great if others could test this with different media players to ensure consistent behavior across the board.

(If there is demand for it in the future, we could look into expanding the second option to distinguish between "paused" and "no active media".)

Disclosure: I used LLMs on the development of this PR.